### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,11 +1,12 @@
 name: FTP Deploy
-permissions:
-  contents: read
 
 on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,4 +1,6 @@
 name: FTP Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NielsDegrande/niels.degran.de/security/code-scanning/1](https://github.com/NielsDegrande/niels.degran.de/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Since the workflow uses `actions/checkout` to access the repository's contents, it requires `contents: read`. No other permissions are necessary for the current workflow.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
